### PR TITLE
Mistral AI OCR & DuckDuckGo search tools defined

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+# Relative imports
+from .config import FilePaths
+
+# Model version
+__version__ = "0.01"
+
+# Load storage paths from config.py
+file_paths = FilePaths()
+api_keys_path = Path(file_paths.api_keys)
+ocr_output_path = Path(file_paths.ocr_output)

--- a/src/agent.py
+++ b/src/agent.py
@@ -1,0 +1,18 @@
+from smolagents import CodeAgent, HfApiModel, DuckDuckGoSearchTool, load_tool, tool
+from smolagents.default_tools import FinalAnswerTool
+
+# Relative imports
+from .tools import ocr_tool
+
+
+
+
+# Define the agent
+# final_answer_tool = FinalAnswerTool()
+# model = HfApiModel(
+#     model_id="deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B")
+
+
+
+# search_tool("What is the capital of France?")
+# ocr_tool("https://arxiv.org/pdf/2501.12948")

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,4 @@
+class FilePaths:
+    def __init__(self):
+        self.api_keys = "C:/ai_agent/api_keys.env"
+        self.ocr_output = "C:/ai_agent/data/"

--- a/src/tools.py
+++ b/src/tools.py
@@ -1,0 +1,58 @@
+import os
+import time
+import random
+from dotenv import load_dotenv
+
+from mistralai import Mistral
+from duckduckgo_search import DDGS
+
+# Relative imports
+from . import api_keys_path, ocr_output_path
+
+# Load environment file containing API keys, and grab the Mistral API key
+load_dotenv(api_keys_path)
+mistral_api_key = os.getenv("MISTRAL_API_KEY", "")
+
+# Define the tools
+def search_tool(query: str) -> list[dict]:
+    """
+    Parse search query via _query_ arg, run search using 
+    DuckDuckGo and return top 5 results.
+    N.B. PLEASE USE SPARINGLY TO AVOID API LIMITS!"""
+
+    try:
+        ddgs = DDGS(headers={"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"})
+        results = ddgs.text(keywords=query,
+                        region="wt-wt",
+                        safesearch="moderate",
+                        timelimit="y",
+                        max_results=5)
+    except Exception as e:
+        print(f"DuckDuckGo API limit reached. Attempting randomized delay: {e}. \nRetrying after a delay...")
+        time.sleep(random.uniform(10, 30))  # Randomized backoff to avoid detection
+    
+    # Only use print() for debugging. REMOVE FOR PRODUCTION
+    print(results)
+
+    return results
+
+
+def ocr_tool(document_url: str) -> str:
+    """Parse document URL via _document_url_ arg, and run OCR using Mistral API."""
+    
+    client = Mistral(api_key=mistral_api_key)
+    
+    pdf_response = client.ocr.process(
+    model="mistral-ocr-latest",
+    document={
+        "type": "document_url",
+        "document_url": document_url,
+    },
+    include_image_base64=True
+    )
+    
+    # Perform markdown on the extracted text
+    extracted_text = "\n\n".join(page.markdown for page in pdf_response.pages)
+    print(extracted_text)
+
+    return extracted_text


### PR DESCRIPTION
Defined two tools for the upcoming AI agent:
- `DuckDuckGo` search tool. However, this API is extremely restrictive, and so should be used very sparingly!
- `Mistral AI OCR` tool. This will perform OCR on any given PDF URL. This API key is on Mistral's free tier, so there will be request limits. Please also use sparingly.