### PR TITLE
Managed to get a Llama-1B model running in a 4-bit quantized state locally

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+duckduckgo_search==8.0.0
+httpx==0.28.1
+markdownify==1.1.0
+mistralai==1.6.0
+pandas==2.0.3
+python-dotenv==1.1.0
+smolagents==1.13.0
+transformers[torch]
+bitsandbytes

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -11,7 +11,7 @@ class FilePaths:
         self.data_path = "C:/ocr_ai_agent/data/"
 
 # Model version
-__version__ = "0.01"
+__version__ = "0.02"
 
 # Load storage paths from FilePaths class
 file_paths = FilePaths()
@@ -24,33 +24,13 @@ mistral_api_key = os.getenv("MISTRAL_API_KEY")
 hf_token = os.getenv("HF_TOKEN")
 langfuse_public_key = os.getenv("LANGFUSE_PUBLIC_KEY")
 langfuse_secret_key = os.getenv("LANGFUSE_SECRET_KEY")
-langfust_host = os.getenv("LANGFUSE_HOST")
+langfuse_host = os.getenv("LANGFUSE_HOST")
 
-# Define LLMs to use
+
+######### DEFINE LLMS TO USE #########
+# LLMs to use with HF API
 qwen_32B = "Qwen/Qwen2.5-Coder-32B-Instruct"
-qwen_1halfB = "Qwen/Qwen2.5-Coder-1.5B-Instruct"
-qwen_7BQuant = "Qwen/Qwen2.5-Coder-7B-Instruct-GPTQ-Int4"
-qwen_1half5BQuant = "Qwen/Qwen2.5-Coder-1.5B-Instruct-AWQ"
 
-######### PROMPT TEMPLATES #########
-# If required, call the following prompt templates ('system_prompt' arg) using the PromptTemplates() class from smolagents
-phi_4_3point8B = "microsoft/Phi-4-mini-instruct"
-phi_4_3point8B_prompt_template = """
-<|system|>You are a helpful assistant with some tools.
-<|tool|>[{"name": "call_ocr_tool", 
-"description": "A tool that performs OCR on a document using Mistral's API.", 
-"parameters": {"document_url": 
-{"description": "The URL of the document to be processed. 
-        Must be a publicly accessible URL pointing to a PDF document,
-        and the user must provide this URL to the agent.", 
-"type": "str"}}},
-{"name": "call_ddgs_search_tool",
-"description": "A tool that performs a DuckDuckGo search. Use this tool if you require
-    additional information from the web that is not provided by the user. Please
-    use this tool sparingly to avoid API limits.",
-"parameters": {"query":
-{"description": "The search query to be run.",
-"type": "str"}}}
-]
-<|/tool|><|end|>
-<|user|>{prompt}<|end|><|assistant|>"""
+# LLMs for local use
+qwen_1half5BQuant = "Qwen/Qwen2.5-Coder-1.5B-Instruct-AWQ"
+llama_1B = "meta-llama/Llama-3.2-1B-Instruct"

--- a/src/agent.py
+++ b/src/agent.py
@@ -1,14 +1,14 @@
 from typing import Dict, Optional
 from pathlib import Path
 
-from smolagents import CodeAgent, tool, PromptTemplates
+from smolagents import CodeAgent, tool
 from smolagents.default_tools import FinalAnswerTool
 import pandas as pd
 
 # Relative imports
 from .tools import mistral_ocr_tool, duckduckgo_search_tool, read_csv_xlsx
-from . import qwen_7BQuant
-from .hf_functions import localTransformersModel
+from . import qwen_1halfB
+from .hf_functions import localQuantizedLlamaModel, localTransformersModel
 
 
 # Call the available tools
@@ -50,22 +50,21 @@ def call_read_csv_xlsx_tool(file_path: Path, sheet_name: Optional[str] = None) -
 
 # Define and run the agent
 final_answer_tool = FinalAnswerTool()
-model = localTransformersModel(qwen_7BQuant)
+model = localTransformersModel(model_id=qwen_1halfB)
 
 prompt = "Please list 3 key insights you are able to glean by conducting a search on the Deepseek R1 technical paper. Additionally, see if you can find the technical paper itself on arxiv. If so, please list the URL of the paper."
 
 agent = CodeAgent(
     model=model,
-    # prompt_templates=messages,
     tools=[final_answer_tool,
            call_ocr_tool,
-           call_ddgs_search_tool],
+           call_ddgs_search_tool,
+           call_read_csv_xlsx_tool],
         max_steps=6,
     verbosity_level=1,
     grammar=None,
     planning_interval=None,
-    name="Research Assistant",
+    name="AI Research Assistant",
     description="An AI Agent that can search the web, perform OCR on documents, read CSV/XLSX files, and answer questions based on the information it finds.",
 )
-agent.run(prompt)
-# agent.run("Perform a summary of the document at this URL: https://arxiv.org/pdf/2501.12948")
+agent.run(prompt, reset=True) # Change 'reset' arg to False when ready to ask the agent follow up questions

--- a/src/hf_functions.py
+++ b/src/hf_functions.py
@@ -1,4 +1,6 @@
 from smolagents import HfApiModel, TransformersModel
+from transformers import AutoModelForCausalLM, BitsAndBytesConfig, AutoTokenizer
+import torch
 
 
 def HFApiCall(hf_token, model_id, max_tokens=2096, temperature=0.5):
@@ -22,7 +24,7 @@ def HFApiCall(hf_token, model_id, max_tokens=2096, temperature=0.5):
     )
 
 
-def localTransformersModel(model_id, temperature=0.6, device_map="auto", torch_dtype="auto"):
+def localTransformersModel(model_id, tokenizer=None, temperature=0.6, device_map="auto", torch_dtype="auto"):
     """
     Use Huggging Face's local Transformers model. Please note that since this uses a 
     local model, please limit your model to only using 1B-3B models, as larger models 
@@ -37,7 +39,54 @@ def localTransformersModel(model_id, temperature=0.6, device_map="auto", torch_d
     print(f"\'hf_token\' not used. Using local Transformers model: {model_id}...")
 
     return TransformersModel(temperature=temperature,
+                             tokenizer=tokenizer,
+                             device="cuda",
                             model_id=model_id,
                             device_map=device_map,
                             torch_dtype=torch_dtype,
                             custom_role_conversions=None)
+
+
+def localQuantizedLlamaModel(model_id, temperature=0.5, max_new_tokens=2096):
+    """Use this Quanitization function with LLAMA models ONLY. This function
+    won't work with other models, since the quantization configurations are 
+    individual to each LLM. Please refer to the model cards on Hugging Face 
+    hub for the specific quantization configurations (if available).
+
+    Args:
+        model_id: The HF model ID to use/download.
+        temperature: The temperature value to use for sampling.
+        max_new_tokens: The maximum number of new tokens to generate."""
+    
+    # Configure quantization
+    quantization_config = BitsAndBytesConfig(
+        load_in_4bit=True,
+        bnb_4bit_compute_dtype=torch.bfloat16,
+        bnb_4bit_use_double_quant=True,
+        bnb_4bit_quant_type="nf4"
+    )
+    
+    # Create a custom TransformersModel that applies quantization when loading
+    class QuantizedTransformersModel(TransformersModel):
+        def __init__(self, model_id, temperature, max_new_tokens):
+            super().__init__(
+                temperature=temperature,
+                max_new_tokens=max_new_tokens,
+                model_id=model_id
+            )
+            
+        def _load_model(self):
+            # Override the model loading method to apply quantization
+            self.model = AutoModelForCausalLM.from_pretrained(
+                self.model_id,
+                device_map="auto",
+                torch_dtype=torch.bfloat16,
+                quantization_config=quantization_config
+            )
+            self.tokenizer = AutoTokenizer.from_pretrained(self.model_id)
+    
+    return QuantizedTransformersModel(
+        model_id=model_id,
+        temperature=temperature,
+        max_new_tokens=max_new_tokens
+    )


### PR DESCRIPTION
`version 0.02`
- Managed to get a Llama-1B model running in a 4-bit quantized state locally. This required a reasonable amount of refactoring (please refer to `src.hf_functions` module at new the function `localQuantizedLlamaModel()` to implement _any_ Llama model in a 4-bit quantized state.
- However, challenges do remain as Llama is not able to recognise the 3 tools I've already written for the agent to use. The agent is currently only generating code of its own, and running into library import restrictions. This is by design as part of smolagents' `CodeAgent()` class to prevent the AI agent from just generating any code that could become harmful or dangerous.
- So the final challenge for me to is get Llama to recognise the existence of the tools I've already written for it!