### PR TITLE
Llama chat template used and smolagents' ToolCallingAgent() class called

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -22,6 +22,7 @@ data_path = Path(file_paths.data_path)
 load_dotenv(api_keys_path)
 mistral_api_key = os.getenv("MISTRAL_API_KEY")
 hf_token = os.getenv("HF_TOKEN")
+serpapi_api_key = os.getenv("SERP_API_KEY")
 langfuse_public_key = os.getenv("LANGFUSE_PUBLIC_KEY")
 langfuse_secret_key = os.getenv("LANGFUSE_SECRET_KEY")
 langfuse_host = os.getenv("LANGFUSE_HOST")
@@ -33,4 +34,5 @@ qwen_32B = "Qwen/Qwen2.5-Coder-32B-Instruct"
 
 # LLMs for local use
 qwen_1half5BQuant = "Qwen/Qwen2.5-Coder-1.5B-Instruct-AWQ"
+qwen_1half5B8bitQuant = "Qwen/Qwen2.5-Coder-1.5B-Instruct-GPTQ-Int8"
 llama_1B = "meta-llama/Llama-3.2-1B-Instruct"

--- a/src/hf_functions.py
+++ b/src/hf_functions.py
@@ -3,7 +3,7 @@ from transformers import AutoModelForCausalLM, BitsAndBytesConfig, AutoTokenizer
 import torch
 
 
-def HFApiCall(hf_token, model_id, max_tokens=2096, temperature=0.5):
+def HFApiCall(hf_token, model_id, max_tokens=1024, temperature=0.5):
     """
     Use Hugging Face API model. Please note that the 'hf_token' is required 
     to use this model, and that we're using the free tier of the API.
@@ -24,7 +24,7 @@ def HFApiCall(hf_token, model_id, max_tokens=2096, temperature=0.5):
     )
 
 
-def localTransformersModel(model_id, tokenizer=None, temperature=0.6, device_map="auto", torch_dtype="auto"):
+def localTransformersModel(model_id, tokenizer=None, temperature=0.5):
     """
     Use Huggging Face's local Transformers model. Please note that since this uses a 
     local model, please limit your model to only using 1B-3B models, as larger models 
@@ -42,12 +42,12 @@ def localTransformersModel(model_id, tokenizer=None, temperature=0.6, device_map
                              tokenizer=tokenizer,
                              device="cuda",
                             model_id=model_id,
-                            device_map=device_map,
-                            torch_dtype=torch_dtype,
+                            device_map="auto",
+                            torch_dtype="auto",
                             custom_role_conversions=None)
 
 
-def localQuantizedLlamaModel(model_id, temperature=0.5, max_new_tokens=2096):
+def localQuantizedLlamaModel(model_id, temperature=0.6, top_p=0.9, max_new_tokens=1024):
     """Use this Quanitization function with LLAMA models ONLY. This function
     won't work with other models, since the quantization configurations are 
     individual to each LLM. Please refer to the model cards on Hugging Face 
@@ -68,9 +68,10 @@ def localQuantizedLlamaModel(model_id, temperature=0.5, max_new_tokens=2096):
     
     # Create a custom TransformersModel that applies quantization when loading
     class QuantizedTransformersModel(TransformersModel):
-        def __init__(self, model_id, temperature, max_new_tokens):
+        def __init__(self, model_id, temperature, top_p, max_new_tokens):
             super().__init__(
                 temperature=temperature,
+                top_p=top_p,
                 max_new_tokens=max_new_tokens,
                 model_id=model_id
             )
@@ -88,5 +89,6 @@ def localQuantizedLlamaModel(model_id, temperature=0.5, max_new_tokens=2096):
     return QuantizedTransformersModel(
         model_id=model_id,
         temperature=temperature,
+        top_p=top_p,
         max_new_tokens=max_new_tokens
     )

--- a/src/llm_chat_templates.py
+++ b/src/llm_chat_templates.py
@@ -2,25 +2,91 @@
 ALSO, WHEN NEW TOOLS ARE BUILT IN TOOLS.PY, PLEASE UPDATE THESE TEMPLATES TO REFLECT THE NEW TOOLS.
 """
 
-llama_system_prompt = """You are an AI assistant that helps users by executing tools as function calls when needed. When you need to make a function call, you must follow this EXACT response format:
+from .tools import duckduckgo_search_tool, google_search_serpapi, mistral_ocr_tool, read_csv_xlsx
 
-Thoughts: [briefly explain your reasoning]
+function_definitions = """[
+        {
+        "name": "google_search_serpapi",
+        "description": "Helper function to run Google searches via SerpAPI.",
+        "parameters": {
+            "type": "dict",
+            "required": ["query"],
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "The search query to be parsed to the Google search engine."
+                },
+                "max_results": {
+                    "type": "integer",
+                    "description": "The maximum number of search results to return."
+                },
+                "full_page": {
+                    "type": "boolean",
+                    "description": "Whether to return full page content or not."
+                }
+            }
+        }
+    },
+    {
+        "name": "duckduckgo_search_tool",
+        "description": "Helper function to parse search query via _query_ arg, run search using DuckDuckGo and return top results.",
+        "parameters": {
+            "type": "dict",
+            "required": ["query"],
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "The search query to be parsed to the DuckDuckGo search engine."
+                },
+                "max_results": {
+                    "type": "integer",
+                    "description": "The maximum number of search results to return."
+                },
+                "full_page": {
+                    "type": "boolean",
+                    "description": "Whether to return full page content or not."
+                }
+            }
+        }
+    },
+    {
+        "name": "mistral_ocr_tool",
+        "description": "Helper function to parse document URL and run OCR using Mistral API.",
+        "parameters": {
+            "type": "dict",
+            "required": ["document_url"],
+            "properties": {
+                "document_url": {
+                    "type": "string",
+                    "description": "The URL of the document to be processed. Must be a publicly accessible URL pointing to a PDF document."
+                }
+            }
+        }
+    },
+]"""
+
+llama_system_prompt = """You are an AI research assistant with access to specific tools to help answer questions.
+
+IMPORTANT: You CANNOT import external libraries like 'requests' or anything else. Attempts to do so will fail.
+
+Instead, use ONLY these available tools:
+- call_ocr_tool(document_url="The URL of the document to be processed")
+- call_google_search_tool(query="The search query to be parsed to the Google search engine")
+- call_ddgs_search_tool(query="The search query to be run") 
+
+When you need to use a tool, your response must follow EXACTLY this format:
+
+Thoughts: [brief explanation of your reasoning]
 Code:
 ```py
-# Your function call here, for example:
-duckduckgo_search_tool(query="search query", max_results=3, full_page=True)
+# Call the appropriate tool
+call_ddgs_search_tool(query="specific search terms")
 ```<end_code>
 
-The code block MUST start with ```py on its own line, contain your Python code, and end with ```<end_code> on its own line.
-
-Available tools:
-- duckduckgo_search_tool(query: str, max_results: int, full_page: bool): Tool call to parse search query via _query_ arg, 
-run search using DuckDuckGo and return top 3 results.
-- mistral_ocr_tool(document_url: str): Tool call to parse document URL via _document_url_ arg, and run OCR using Mistral API.
-- read_csv_xlsx(file_path: Path, sheet_name: Optional[str]): Tool call to read CSV or XLSX files from a user provided file path 
-and returns a Pandas DataFrame.
-
-DO NOT include function definitions or explanations in your code block. ONLY include the actual function calls.
-"""
+DO NOT attempt additional imports of any sort that are not listed above.
+DO NOT try to define your own functions.
+ONLY use the pre-defined tools listed above. Here's the above list of functions in JSON format that you can invoke:
+{functions}
+""".format(functions=function_definitions)
 
 prompt = "Please list 3 key insights you are able to glean by conducting a search on the Deepseek R1 technical paper. Additionally, see if you can find the technical paper itself on arxiv. If so, please list the URL of the paper."

--- a/src/tools.py
+++ b/src/tools.py
@@ -7,10 +7,11 @@ from pathlib import Path
 
 from mistralai import Mistral
 from duckduckgo_search import DDGS
+from serpapi import search
 import pandas as pd
 
 # Relative imports
-from . import mistral_api_key
+from . import mistral_api_key, serpapi_api_key
 
 def fetch_full_page(url: str) -> Optional[str]:
     """Helper function to fetch full page content from a URL."""
@@ -70,6 +71,24 @@ def duckduckgo_search_tool(query: str, max_results: int = 3, full_page: bool = T
         print(f"Full error stack trace: {type(e).__name__}")
 
     return results
+
+def google_search_serpapi(query: str) -> Dict[str, dict[str, any]]:
+    """
+    Helper function to run Google searches via SerpAPI.
+    
+    Args:
+        query: The search query to be parsed to the Google search engine."""
+
+    params_dict = {"q": query, 
+                   "location": "Melbourne, Australia",
+                    "hl": "en",
+                    "gl": "au",
+                    "google_domain": "google.com.au",
+                    "api_key": serpapi_api_key}
+
+    search_results = search(**params_dict)
+    
+    return search_results
 
 
 def mistral_ocr_tool(document_url: str) -> str:


### PR DESCRIPTION
- Llama chat template used and smolagents' `ToolCallingAgent()` class called, since this quantized Llama LLM seems to be a tool calling agent that seems to have the capability for being a Code Agent. However, when it's used as a Code Agent (i.e. `CodeAgent()` class), it ignores the tools that I've built for it, and instead chooses to generate code of its own from scratch. This is highly dangerous and is explicitly disallowed by smolagents to prevent accidental malicious code being written and executed by the LLM. In the LLMs zeal to be helpful, it can write code that has the capacity to destroy a system! As such, by default, smolagents black lists any python import, but instead allows us, the developers, the ability to whitelist any particular python libraries that we explicitly feel comfortable with the LLM to use.
- Looking at Llama's dev documentation (https://www.llama.com/docs/model-cards-and-prompt-formats/llama3_2/#-tool-calling) they seem to only use JSON blobs for tool calling. But, when used it still doesn't seem to use the tools effectively, but instead makes nonsensical calls to the tools being defined in the JSON blob that I've defined in the `src.llm_chat_templates` module.
- I'm still pushing this code to the repo, for version control reasons, but getting this model to work on a local machine with only 8GB of VRAM is proving to be extremely challenging!